### PR TITLE
Add `api-version: 1.13`

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,7 @@
 name: HealAndFeed
 version: 1.0.1
 main: tonimatasmc.healandfeed.HealAndFeed
+api-version: 1.13
 
 commands:
   feed:


### PR DESCRIPTION
Stops legacy material support from being initialised and removes this warn:
```
[Server thread/WARN]: Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!
[Server thread/WARN]: Legacy plugin HealAndFeed v1.0.1 does not specify an api-version.
```